### PR TITLE
Removed maximized start.

### DIFF
--- a/src/main/java/io/swaglabs/portal/qa/browsermanager/ChromeBrowser.java
+++ b/src/main/java/io/swaglabs/portal/qa/browsermanager/ChromeBrowser.java
@@ -6,15 +6,12 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Playwright;
 import io.swaglabs.portal.qa.constants.WebPortalConstants;
 
-import java.util.Collections;
-
 public class ChromeBrowser implements IBrowser {
 
     @Override
     public BrowserContext createSession(Playwright playwright, boolean isHeadless) {
         return playwright.chromium().launch(new BrowserType.LaunchOptions()
-                        .setHeadless(isHeadless)
-                        .setArgs(Collections.singletonList(WebPortalConstants.MAXIMIZE_WINDOW)))
+                        .setHeadless(isHeadless))
                 .newContext(new Browser.NewContextOptions()
                         .setViewportSize(WebPortalConstants.SCREEN_WIDTH, WebPortalConstants.SCREEN_HEIGHT));
     }

--- a/src/main/java/io/swaglabs/portal/qa/browsermanager/FirefoxBrowser.java
+++ b/src/main/java/io/swaglabs/portal/qa/browsermanager/FirefoxBrowser.java
@@ -6,14 +6,11 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Playwright;
 import io.swaglabs.portal.qa.constants.WebPortalConstants;
 
-import java.util.Collections;
-
 public class FirefoxBrowser implements IBrowser {
     @Override
     public BrowserContext createSession(Playwright playwright, boolean isHeadless) {
         return playwright.firefox().launch(new BrowserType.LaunchOptions()
-                        .setHeadless(isHeadless)
-                        .setArgs(Collections.singletonList(WebPortalConstants.MAXIMIZE_WINDOW)))
+                        .setHeadless(isHeadless))
                 .newContext(new Browser.NewContextOptions()
                         .setViewportSize(WebPortalConstants.SCREEN_WIDTH, WebPortalConstants.SCREEN_HEIGHT));
     }

--- a/src/main/java/io/swaglabs/portal/qa/browsermanager/MsEdgeBrowser.java
+++ b/src/main/java/io/swaglabs/portal/qa/browsermanager/MsEdgeBrowser.java
@@ -6,17 +6,11 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Playwright;
 import io.swaglabs.portal.qa.constants.WebPortalConstants;
 
-import java.util.List;
-
 public class MsEdgeBrowser implements IBrowser {
     @Override
     public BrowserContext createSession(Playwright playwright, boolean isHeadless) {
         return playwright.chromium().launch(new BrowserType.LaunchOptions()
-                        .setHeadless(isHeadless)
-                        .setArgs(isHeadless
-                                ? List.of("--headless=new", WebPortalConstants.MAXIMIZE_WINDOW)
-                                : List.of(WebPortalConstants.MAXIMIZE_WINDOW))
-                        .setChannel(BrowserName.MS_EDGE.getBrowserType()))
+                        .setHeadless(isHeadless).setChannel(BrowserName.MS_EDGE.getBrowserType()))
                 .newContext(new Browser.NewContextOptions()
                         .setViewportSize(WebPortalConstants.SCREEN_WIDTH, WebPortalConstants.SCREEN_HEIGHT));
     }

--- a/src/main/java/io/swaglabs/portal/qa/browsermanager/WebkitBrowser.java
+++ b/src/main/java/io/swaglabs/portal/qa/browsermanager/WebkitBrowser.java
@@ -6,14 +6,11 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Playwright;
 import io.swaglabs.portal.qa.constants.WebPortalConstants;
 
-import java.util.Collections;
-
 public class WebkitBrowser implements IBrowser {
     @Override
     public BrowserContext createSession(Playwright playwright, boolean isHeadless) {
         return playwright.webkit().launch(new BrowserType.LaunchOptions()
-                        .setHeadless(isHeadless)
-                        .setArgs(Collections.singletonList(WebPortalConstants.MAXIMIZE_WINDOW)))
+                        .setHeadless(isHeadless))
                 .newContext(new Browser.NewContextOptions()
                         .setViewportSize(WebPortalConstants.SCREEN_WIDTH, WebPortalConstants.SCREEN_HEIGHT));
     }


### PR DESCRIPTION

Aspect | Effective? | Explanation
-- | -- | --
--start-maximized | ❌ | Ignored due to newContext() isolation
setViewportSize(...) | ✅ | Controls the actual render area
Real maximization (fullscreen) | ❌ | Not applicable unless using launchPersistentContext() in non-headless mode

