### PR TITLE
Implemented methods to catch RunTime exceptions from browser console.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
                 <configuration>
-                    <reportFormat>plain</reportFormat>
-                    <consoleOutputReporter>
-                        <disable>true</disable>
-                    </consoleOutputReporter>
                     <statelessTestsetInfoReporter
                             implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode"/>
                     <parallel>methods</parallel>

--- a/src/main/java/io/swaglabs/portal/qa/cdp/CdpCommands.java
+++ b/src/main/java/io/swaglabs/portal/qa/cdp/CdpCommands.java
@@ -9,7 +9,8 @@ public enum CdpCommands {
 
     NETWORK_ENABLE("Network.enable"),
     CONSOLE_ENABLE("Console.enable"),
-    PAGE_ENABLE("Page.enable");
+    PAGE_ENABLE("Page.enable"),
+    RUNTIME_ENABLE("Runtime.enable");
 
     private final String description;
 }

--- a/src/main/java/io/swaglabs/portal/qa/cdp/CdpEvents.java
+++ b/src/main/java/io/swaglabs/portal/qa/cdp/CdpEvents.java
@@ -11,7 +11,9 @@ public enum CdpEvents {
     NETWORK_RESPONSE_RECEIVED("Network.responseReceived"),
     CONSOLE_MESSAGE_ADDED("Console.messageAdded"),
     PAGE_LOAD_EVENT_FIRED("Page.loadEventFired"),
-    PAGE_NAVIGATED_WITHIN_DOCUMENT("Page.navigatedWithinDocument");
+    PAGE_NAVIGATED_WITHIN_DOCUMENT("Page.navigatedWithinDocument"),
+    RUNTIME_EXCEPTION_THROWN("Runtime.exceptionThrown"),
+    RUNTIME_CONSOLE_API_CALLED("Runtime.consoleAPICalled");
 
     private final String description;
 }

--- a/src/test/java/io/swaglabs/portal/qa/commons/WebBaseTest.java
+++ b/src/test/java/io/swaglabs/portal/qa/commons/WebBaseTest.java
@@ -44,6 +44,9 @@ public abstract class WebBaseTest {
             CdpUtils.logErrorResponses();
             CdpUtils.sendCommand(CdpCommands.CONSOLE_ENABLE.getDescription());
             CdpUtils.logConsoleErrors();
+            CdpUtils.sendCommand(CdpCommands.RUNTIME_ENABLE.getDescription());
+            CdpUtils.logUncaughtJavascriptErrors();
+            CdpUtils.logUncaughtConsoleErrors();
             CdpUtils.sendCommand(CdpCommands.PAGE_ENABLE.getDescription());
             CdpUtils.logPageLoadCompletion();
             CdpUtils.logPageNavigatedWithinDocument();


### PR DESCRIPTION
- Removed <reportFormat> & <consoleOutputReporter> tags
- Implemented a method to capture JavaScript runtime exceptions.
- Implemented a method to listen for uncaught promise rejections through console API.